### PR TITLE
merge(feat-heroku-deployment): Get Web Client Working Through Heroku

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "author": " ",
   "private": true,
   "scripts": {
+    "postinstall": "npm run build",
     "dev": "node build/dev-server.js",
     "start": "node build/dev-server.js",
     "build": "node build/build.js",

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,6 @@
   "author": " ",
   "private": true,
   "scripts": {
-    "postinstall": "npm run build",
     "dev": "node build/dev-server.js",
     "start": "node build/dev-server.js",
     "build": "node build/build.js",

--- a/server/bug-bounty/Startup.cs
+++ b/server/bug-bounty/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -8,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Proxy;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -34,14 +36,23 @@ namespace bug_bounty
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                app.MapWhen(IsNotApi, builder => builder.RunProxy(new ProxyOptions
+                {
+                    Scheme = "http",
+                    Host = "localhost",
+                    Port = "8080",
+                }));
+            }
+            else
+            {
+                app.UseDefaultFiles();
+                app.UseStaticFiles(new StaticFileOptions
+                {
+                    FileProvider = new PhysicalFileProvider(Path.Combine(Directory.GetCurrentDirectory(), "wwwroot")),
+                    RequestPath = new PathString(""),
+                });
             }
 
-            app.MapWhen(IsNotApi, builder => builder.RunProxy(new ProxyOptions
-            {
-                Scheme = "http",
-                Host = "localhost",
-                Port = "8080",
-            }));
             app.UseMvc();
         }
 

--- a/server/bug-bounty/bug-bounty.csproj
+++ b/server/bug-bounty/bug-bounty.csproj
@@ -12,4 +12,11 @@
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
   </ItemGroup>
+  <ItemGroup>
+    <WebAssets Include="../../client/dist/**" CopyToPublishDirectory="Always" />
+  </ItemGroup>
+  <Target Name="MakeWWWRoot" AfterTargets="Publish">
+    <MakeDir Directories="$(PublishDir)wwwroot" />
+    <Copy SourceFiles="@(WebAssets)" DestinationFiles="@(WebAssets->'$(PublishDir)wwwroot\%(RecursiveDir)%(Filename)%(Extension)')" />
+  </Target>
 </Project>

--- a/server/bug-bounty/bug-bounty.csproj
+++ b/server/bug-bounty/bug-bounty.csproj
@@ -12,15 +12,12 @@
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
   </ItemGroup>
-  <ItemGroup>
-    <WebAssets Include="../../client/dist/**" CopyToPublishDirectory="Always" />
-  </ItemGroup>
   <Target Name="PublishClientApp" AfterTargets="Publish">
     <Exec Command="cd ../../client &amp;&amp; npm install" />
     <Exec Command="npm --prefix ../../client run build" />
 
     <MakeDir Directories="$(PublishDir)wwwroot" />
-    <Copy SourceFiles="@(WebAssets)" DestinationFiles="@(WebAssets->'$(PublishDir)wwwroot\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Exec Command="cp -r ../../client/dist/* $(PublishDir)wwwroot" />
   </Target>
   <Target Name="RemoveDevelopmentAssets" AfterTargets="Publish">
     <Exec Command="rm -r ../../client/node_modules" />

--- a/server/bug-bounty/bug-bounty.csproj
+++ b/server/bug-bounty/bug-bounty.csproj
@@ -15,7 +15,10 @@
   <ItemGroup>
     <WebAssets Include="../../client/dist/**" CopyToPublishDirectory="Always" />
   </ItemGroup>
-  <Target Name="MakeWWWRoot" AfterTargets="Publish">
+  <Target Name="PublishClientApp" AfterTargets="Publish">
+    <Exec Command="cd ../../client &amp;&amp; npm install" />
+    <Exec Command="npm --prefix ../../client run build" />
+
     <MakeDir Directories="$(PublishDir)wwwroot" />
     <Copy SourceFiles="@(WebAssets)" DestinationFiles="@(WebAssets->'$(PublishDir)wwwroot\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>

--- a/server/bug-bounty/bug-bounty.csproj
+++ b/server/bug-bounty/bug-bounty.csproj
@@ -22,4 +22,8 @@
     <MakeDir Directories="$(PublishDir)wwwroot" />
     <Copy SourceFiles="@(WebAssets)" DestinationFiles="@(WebAssets->'$(PublishDir)wwwroot\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
+  <Target Name="RemoveDevelopmentAssets" AfterTargets="Publish">
+    <Exec Command="rm -r ../../client/node_modules" />
+    <Exec Command="rm -r bin" />
+  </Target>
 </Project>


### PR DESCRIPTION
Updating the ASPNET Core to serve the build client assets as static files.

The msbuild file will trigger an npm build, and will move the contents of the `dist` folder into a `wwwroot` folder in the PublishDir output folder from the dotnet publish command. This can then be served using a path relative to the published dll, and accessed from the index page.