### PR TITLE
feat(launch-server): Automatically Open Browser to Served Proxy

### DIFF
--- a/client/build/dev-server.js
+++ b/client/build/dev-server.js
@@ -17,7 +17,7 @@ var webpackConfig = (process.env.NODE_ENV === 'testing' || process.env.NODE_ENV 
 // default port where dev server listens for incoming traffic
 var port = process.env.PORT || config.dev.port
 // automatically open browser, if not set will be false
-var autoOpenBrowser = !!config.dev.autoOpenBrowser
+var autoOpenBrowser = !process.env.NO_BROWSER ? !!config.dev.autoOpenBrowser : false
 // Define HTTP proxies to your custom API backend
 // https://github.com/chimurai/http-proxy-middleware
 var proxyTable = config.dev.proxyTable

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Track and gamify public contributions to projects.",
   "main": "index.js",
   "scripts": {
-    "start": "concurrently \"npm --prefix client run start\" \"ASPNETCORE_ENVIRONMENT=Development dotnet run --project server/bug-bounty/bug-bounty.csproj\"",
+    "start": "concurrently \"NO_BROWSER=true npm --prefix client run start\" \"ASPNETCORE_ENVIRONMENT=Development dotnet run --project server/bug-bounty/bug-bounty.csproj\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/server/bug-bounty/Startup.cs
+++ b/server/bug-bounty/Startup.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -42,6 +44,8 @@ namespace bug_bounty
                     Host = "localhost",
                     Port = "8080",
                 }));
+
+                OpenBrowser("http://localhost:5000");
             }
             else
             {
@@ -59,6 +63,35 @@ namespace bug_bounty
         private bool IsNotApi(HttpContext context)
         {
             return !context.Request.Path.Value.StartsWith("/api");
+        }
+
+        private void OpenBrowser(string url)
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo("cmd.exe", $"/c start {url}") { CreateNoWindow = true });
+            }
+            catch (Exception e)
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    url = url.Replace("&", "^&");
+                    Process.Start(new ProcessStartInfo("cmd.exe", $"/c start {url}") { CreateNoWindow = true });
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    Console.WriteLine("Trying linux");
+                    Process.Start("xdg-open", url);
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    Process.Start("open", url);
+                }
+                else
+                {
+                    throw;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Rather than opening the client browser page, the root package.json
serve command will launch the server root page which proxies the
development web server.